### PR TITLE
fix: ビルドエラーの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "repository": "https://github.com/citation-dev/citation.m2en.dev/citation.m2en.dev",
   "scripts": {
-    "dev": "NODE_OPTIONS='--openssl-legacy-provider' vuepress dev src",
-    "build": "NODE_OPTIONS='--openssl-legacy-provider' vuepress build src"
+    "dev": "vuepress dev src",
+    "build": "vuepress build src"
   },
   "license": "MIT",
   "devDependencies": {

--- a/src/en/guide/README.md
+++ b/src/en/guide/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the citation guide.
 
-The guide explains how to set up ## citationon and how to customize it.
+The guide explains how to set up citation and how to customize it.
 
 ## What is citation?
 

--- a/src/en/reference/community/permissions.md
+++ b/src/en/reference/community/permissions.md
@@ -48,5 +48,4 @@ You can have per-command settings from the `command` sector. This takes preceden
 
 Check the Discord Help Center for detailed settings
 
-[Command Permissions - Discord Help Center](https://support.discord.com/hc/ja/articles/4644915651095)
-]()
+[Command Permissions - Discord Help Center](https://support.discord.com/hc/en-us/articles/4644915651095)

--- a/src/en/reference/features/citation.md
+++ b/src/en/reference/features/citation.md
@@ -69,7 +69,7 @@ Users with message management or administrator privileges can also delete quotes
 
 For more information about spoilers, please refer to the official help article.
 
-[spoiler tag! - Discord Help Center](https://support.discord.com/hc/ja/articles/360022320632)
+[spoiler tag! - Discord Help Center](https://support.discord.com/hc/en-us/articles/360022320632)
 
 ::::
 
@@ -106,7 +106,7 @@ Ephemeral messages are messages that are handled by the Interaction API for appl
 
 For details, please refer to the official help article.
 
-[Ephemeral Messages FAQ - Discord Help Center](https://support.discord.com/hc/ja/articles/1500000580222)
+[Ephemeral Messages FAQ - Discord Help Center](https://support.discord.com/hc/en-us/articles/1500000580222)
 
 ::::
 


### PR DESCRIPTION
### 関連したIssue

close #6 
close #7 

### 概要

VuePress v1で発生していたOpenSSLに関する不具合を黙らせるために使用していた `--openssl-legacy-provider` は、 #1 にて移行した VuePress v2 から必要なくなったため、削除します。

これにより #6 で確認したビルドCIのエラーは無くなると思われます。

ついでに英語版のガイド・リファレンスにおけるDiscord ヘルプセンターの記事へのリンクはすべて英語版に置き換えました。
